### PR TITLE
Add color and size tag support

### DIFF
--- a/lib/rbbcode.rb
+++ b/lib/rbbcode.rb
@@ -27,9 +27,10 @@ class RbbCode
   end
   
   def initialize(options = {})
-    @options = {
+    @@options = {
       :output_format => :html,
       :sanitize => true,
+      :unsupported_features => :remove,
       :sanitize_config => RbbCode::DEFAULT_SANITIZE_CONFIG
     }.merge(options)
   end
@@ -39,26 +40,34 @@ class RbbCode
     bb_code = bb_code.gsub("\r\n", "\n").gsub("\r", "\n")
     # Add linebreaks before and after so that paragraphs etc. can be recognized.
     bb_code = "\n\n" + bb_code + "\n\n"
-    output = self.class.parser_class.new.parse(bb_code).send("to_#{@options[:output_format]}")
-    if @options[:emoticons]
+    output = self.class.parser_class.new.parse(bb_code).send("to_#{output_format}")
+    if options[:emoticons]
       output = convert_emoticons(output)
     end
     # Sanitization works for HTML only.
-    if @options[:output_format] == :html and @options[:sanitize]
-      Sanitize.clean(output, @options[:sanitize_config])
+    if output_format == :html and options[:sanitize]
+      Sanitize.clean(output, options[:sanitize_config])
     else
       output
     end
   end
 
   def convert_emoticons(output)
-    @options[:emoticons].each do |emoticon, url|
+    options[:emoticons].each do |emoticon, url|
       output.gsub!(emoticon, '<img src="' + url + '" alt="Emoticon"/>')
     end
     output
   end
 
   def output_format
-    @options[:output_format]
+    options[:output_format]
+  end
+
+  def options
+    @@options
+  end
+
+  def self.options
+    @@options
   end
 end

--- a/lib/rbbcode/node_extensions.rb
+++ b/lib/rbbcode/node_extensions.rb
@@ -189,11 +189,19 @@ class RbbCode
   # of TagNode, which calls to ColorTagNode when processing a color tag.
   module ColorTagNode
     def color_to_html
-      text.text_value
+      unsupported_tag
     end
 
     def color_to_markdown
-      text.text_value
+      unsupported_tag
+    end
+
+    def unsupported_tag
+      if RbbCode.options.fetch(:unsupported_features) == :remove
+        text.text_value
+      elsif RbbCode.options.fetch(:unsupported_features) == :span
+        '<span class="' + color_name.text_value + '">' + text.text_value + '</span>'
+      end
     end
   end
 
@@ -201,11 +209,19 @@ class RbbCode
   # of TagNode, which calls to SizeTagNode when processing a size tag.
   module SizeTagNode
     def size_to_html
-      text.text_value
+      unsupported_tag
     end
 
     def size_to_markdown
-      text.text_value
+      unsupported_tag
+    end
+
+    def unsupported_tag
+      if RbbCode.options.fetch(:unsupported_features) == :remove
+        text.text_value
+      elsif RbbCode.options.fetch(:unsupported_features) == :span
+        '<span class="size' + size_value.text_value + '">' + text.text_value + '</span>'
+      end
     end
   end
 

--- a/lib/rbbcode/node_extensions.rb
+++ b/lib/rbbcode/node_extensions.rb
@@ -185,6 +185,30 @@ class RbbCode
     end
   end
 
+  # You won't find this module in the .treetop file. Instead, it's effectively a specialization
+  # of TagNode, which calls to ColorTagNode when processing a color tag.
+  module ColorTagNode
+    def color_to_html
+      text.text_value
+    end
+
+    def color_to_markdown
+      text.text_value
+    end
+  end
+
+  # You won't find this module in the .treetop file. Instead, it's effectively a specialization
+  # of TagNode, which calls to SizeTagNode when processing a size tag.
+  module SizeTagNode
+    def size_to_html
+      text.text_value
+    end
+
+    def size_to_markdown
+      text.text_value
+    end
+  end
+
   module UTagNode
     def u_to_markdown
       # Underlining is unsupported in Markdown. So we just ignore [u] tags.
@@ -198,8 +222,24 @@ class RbbCode
     # For each tag name, we can either: (a) map to a simple HTML tag or Markdown character, or
     # (b) invoke a separate Ruby module for more advanced logic.
     TAG_MAPPINGS = {
-      html: {'b' => 'strong', 'i' => 'em', 'u' => 'u', 'url' => URLTagNode, 'img' => ImgTagNode},
-      markdown: {'b' => '**', 'i' => '*', 'u' => UTagNode, 'url' => URLTagNode, 'img' => ImgTagNode}
+      html: {
+        'b' => 'strong',
+        'i' => 'em',
+        'u' => 'u',
+        'url' => URLTagNode,
+        'img' => ImgTagNode,
+        'color' => ColorTagNode,
+        'size' => SizeTagNode
+      },
+      markdown: {
+        'b' => '**',
+        'i' => '*',
+        'u' => UTagNode,
+        'url' => URLTagNode,
+        'img' => ImgTagNode,
+        'color' => ColorTagNode,
+        'size' => SizeTagNode
+      }
     }
     
     def contents

--- a/lib/rbbcode/rbbcode_grammar.treetop
+++ b/lib/rbbcode/rbbcode_grammar.treetop
@@ -92,7 +92,7 @@ grammar RbbCodeGrammar
   
   rule tag
     # Make sure that anytime you call def_tag, you add it to this list:
-    (bold / italic / underline / simple_url / complex_url / img)
+    (bold / italic / underline / simple_url / complex_url / img / color / size)
     <RbbCode::TagNode>
   end
   
@@ -101,7 +101,19 @@ grammar RbbCodeGrammar
   <%= def_tag 'underline', 'u' %>
   <%= def_tag 'simple_url', 'url' %>
   <%= def_tag 'img', 'img' %>
-  
+
+  rule size
+    '[size=' size_value:[^\]]+ ']'
+    text:(!'[/size]' .)+
+    '[/size]'
+  end
+
+  rule color
+    '[color=' color_name:[^\]]+ ']'
+    text:(!'[/color]' .)+
+    '[/color]'
+  end
+
   rule complex_url
     '[url=' url:[^\]]+ ']'
     text:(!'[/url]' .)+

--- a/test/unsupported_features_test.rb
+++ b/test/unsupported_features_test.rb
@@ -3,35 +3,36 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'test_helper.rb')
 class TestUnsupportedFeatures < Minitest::Test
   include RbbCode::OutputAssertions
 
-  def test_remove_color_tag_to_html
+  def test_remove_color_and_size_tags_to_html
     assert_converts_to(
-      '<p>Not colored but <strong>bold.</strong></p>',
-      'Not [color=red]colored[/color] but [b]bold.[/b]',
+      '<p>Not colored or resized but <strong>bold.</strong></p>',
+      'Not [color=red]colored[/color] or [size=3]resized[/size] but [b]bold.[/b]',
       {}
     )
   end
 
-  def test_remove_color_tag_to_markdown
+  def test_remove_color_and_size_tags_to_markdown
     assert_converts_to(
-      "Not colored but **bold.**\n\n",
-      'Not [color=red]colored[/color] but [b]bold.[/b]',
+      "Not colored or resized but **bold.**\n\n",
+      'Not [color=red]colored[/color] or [size=3]resized[/size] but [b]bold.[/b]',
       { output_format: :markdown }
     )
   end
 
-  def test_remove_size_tag_to_html
+  def test_color_and_size_with_span_tags_to_html
     assert_converts_to(
-      '<p>Not resized but <strong>bold.</strong></p>',
-      'Not [size=3]resized[/size] but [b]bold.[/b]',
-      {}
+      '<p>Not colored or resized but <strong>bold.</strong></p>',
+      'Not [color=red]colored[/color] or [size=3]resized[/size] but [b]bold.[/b]',
+      { :unsupported_features => :span }
     )
   end
 
-  def test_remove_size_tag_to_markdown
+  def test_color_and_size_with_tags_to_markdown
     assert_converts_to(
-      "Not resized but **bold.**\n\n",
-      'Not [size=3]resized[/size] but [b]bold.[/b]',
-      { output_format: :markdown }
+      "Not <span class=\"red\">colored</span> or <span class=\"size3\">resized</span> but **bold.**\n\n",
+      'Not [color=red]colored[/color] or [size=3]resized[/size] but [b]bold.[/b]',
+      { :unsupported_features => :span, output_format: :markdown }
     )
   end
+
 end

--- a/test/unsupported_features_test.rb
+++ b/test/unsupported_features_test.rb
@@ -1,0 +1,37 @@
+require File.join(File.expand_path(File.dirname(__FILE__)), 'test_helper.rb')
+
+class TestUnsupportedFeatures < Minitest::Test
+  include RbbCode::OutputAssertions
+
+  def test_remove_color_tag_to_html
+    assert_converts_to(
+      '<p>Not colored but <strong>bold.</strong></p>',
+      'Not [color=red]colored[/color] but [b]bold.[/b]',
+      {}
+    )
+  end
+
+  def test_remove_color_tag_to_markdown
+    assert_converts_to(
+      "Not colored but **bold.**\n\n",
+      'Not [color=red]colored[/color] but [b]bold.[/b]',
+      { output_format: :markdown }
+    )
+  end
+
+  def test_remove_size_tag_to_html
+    assert_converts_to(
+      '<p>Not resized but <strong>bold.</strong></p>',
+      'Not [size=3]resized[/size] but [b]bold.[/b]',
+      {}
+    )
+  end
+
+  def test_remove_size_tag_to_markdown
+    assert_converts_to(
+      "Not resized but **bold.**\n\n",
+      'Not [size=3]resized[/size] but [b]bold.[/b]',
+      { output_format: :markdown }
+    )
+  end
+end


### PR DESCRIPTION
This is relating to #26 

I opted to only have the options for `:span` and `:remove` for now. I'm not entirely happy about the use of global option, but I didn't want to rebuild the whole configuration management.